### PR TITLE
Add ClientRPC Attribute & RPCCaller system

### DIFF
--- a/Client/src/API/RPCCaller.cs
+++ b/Client/src/API/RPCCaller.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using Carbon.Client.Base;
+using Network;
+using UnityEngine;
+
+namespace Carbon.Client.API;
+
+public class RPCCaller
+{
+
+    public static BaseEntity.RPCMessage reusableRPC = new();
+
+    public static bool CallRPC(BaseEntity entity, BasePlayer player, uint rpc, Message message)
+    {
+
+        bool result = false;
+        if (!RPCLoader.FindRPCs(rpc, out List<BaseRPC> method))
+			return result;
+
+		if(method.Count == 0) 
+			return result;
+
+        reusableRPC.player = player;
+        reusableRPC.connection = message.connection;
+        reusableRPC.read = message.read;
+        for (int i = 0; i < method.Count; i++)
+		{
+			var methodResult = method[i].Callback?.Invoke((BaseEntity)entity, reusableRPC) ?? false;
+			if(methodResult == true)
+			{
+				result = true;
+				// Discression for Raul: uncomment this if you only want to call RPC methods until the call is handled
+				// break;
+			}
+        }
+
+		reusableRPC.player = null;
+		reusableRPC.connection = null;
+		reusableRPC.read = null;
+
+		return result;
+	}
+}

--- a/Client/src/API/RPCLoader.cs
+++ b/Client/src/API/RPCLoader.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Carbon.Client.Base;
+using Carbon.Utility;
+using Il2CppInterop.Runtime;
+using Il2CppInterop.Runtime.Injection;
+using UnityEngine;
+
+namespace Carbon.Client.API;
+
+public class RPCLoader
+{
+
+    public static Dictionary<uint, List<BaseRPC>> RPCMethods = new();
+
+	internal const BindingFlags _flag = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+	
+	internal static Type baseEntityType = typeof(BaseEntity);
+
+    private static object[] staticArgs = new object[2];
+
+    private static object[] instanceArgs = new object[1];
+
+	public static bool FindRPCs(uint rpc, out List<BaseRPC> rpcMethods)
+	{
+		return RPCMethods.TryGetValue(rpc, out rpcMethods);
+	}
+	public static void RegisterPlugin(CarbonClientPlugin plugin)
+	{
+        var type = plugin.GetType();
+		RegisterType(type, plugin);
+        foreach(var child in type.GetNestedTypes())
+        {
+            RegisterType(child, plugin);
+        }
+	}
+
+	private static void RegisterType(Type type, CarbonClientPlugin plugin)
+	{
+        foreach (var method in type.GetMethods(_flag))
+        {
+            var attribute = method.GetCustomAttribute<ClientRPCAttribute>();
+            if (attribute == null)
+            {
+                continue;
+            }
+
+            bool isPluginType = typeof(CarbonClientPlugin).IsAssignableFrom(type);
+            Type entityType = null;
+            var name = (string.IsNullOrEmpty(attribute.Name) ? method.Name : attribute.Name);
+            var rpc = StringPool.Add(name);
+
+
+            // attempt to find the entity type:
+            // if the method has 2 parameters, assume the first is the entity
+            // if the method only has one, assume its the type itself is the entity type
+            // otherwise skip as this RPC has an invalid signature
+            var parameters = method.GetParameters();
+            if(parameters.Length == 0) {
+                continue;
+            }
+            else if (parameters.Length >= 2)
+            {
+                entityType = parameters[0].ParameterType;
+            } 
+            else
+            {
+                if (isPluginType)
+                    continue;
+                entityType = type;
+            }
+            if (!baseEntityType.IsAssignableFrom(entityType))
+                continue;
+
+            if (!ClassInjector.IsTypeRegisteredInIl2Cpp(entityType))
+                ClassInjector.RegisterTypeInIl2Cpp(entityType);
+            var il2cppEntityType = Il2CppType.From(entityType);
+            Add(new BaseRPC
+            {
+                Name = name,
+                ID = rpc,
+                Plugin = plugin,
+                EntityType = il2cppEntityType,
+                InstanceRPC = isPluginType,
+                Callback = (entity, message) =>
+                {
+                    var ob = (entity as Il2CppSystem.Object);
+                    
+                    // the Il2Cpp way of checking and casting one type to another at runtime
+                    if (!il2cppEntityType.IsAssignableFrom(ob.GetIl2CppType()))
+                        return false;
+                    entity = NonGenericIl2CppConverter.Convert(entityType, ob.Pointer);
+
+                    object instance = null;
+                    object result = null;
+                    object[] args = null;
+
+                    if (method.IsStatic)
+                    {
+                        args = staticArgs;
+                        args[0] = entity;
+                        args[1] = message;
+                    }
+                    else if (!isPluginType)
+                    {
+                        args = instanceArgs;
+                        args[0] = message;
+                        instance = entity;
+                    }
+                    else
+                    {
+                        args = staticArgs;
+                        args[0] = entity;
+                        args[1] = message;
+                        instance = plugin;
+                    }
+                    result = method.Invoke(instance, args);
+                    Array.Clear(args);
+                    return (result is bool bResult ? bResult : false);
+                }
+            });
+
+            Debug.Log($"Installed RPC '{name}' [{type.Name}]");
+        }
+    }
+    
+    private static void Add(BaseRPC method)
+    {
+        if (!RPCMethods.TryGetValue(method.ID, out List<BaseRPC> list))
+            RPCMethods.Add(method.ID, list = new List<BaseRPC>());
+
+        list.Add(method);
+    }
+
+	public static void UnregisterPlugin(CarbonClientPlugin plugin)
+	{
+        foreach (var kvp in RPCMethods)
+        {
+            for(int i = kvp.Value.Count - 1; i >= 0; i--)
+            {
+                if (kvp.Value[i].Plugin == plugin)
+                    kvp.Value.RemoveAt(i);
+            }
+        }
+	}
+}

--- a/Client/src/Base/BaseRPC.cs
+++ b/Client/src/Base/BaseRPC.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Carbon.Client.Base;
+using Carbon.Extensions;
+
+namespace Carbon.Client.Base
+{
+	public class BaseRPC
+	{
+		public CarbonClientPlugin Plugin { get; set; }
+
+		public Il2CppSystem.Type EntityType { get; set; }
+
+		public string Name { get; set; }
+        public uint ID { get; set; }
+
+		public bool InstanceRPC { get; set; }
+
+        public Func<object, BaseEntity.RPCMessage, bool> Callback { get; set; }
+	}
+}

--- a/Client/src/Compiler/Atributes.cs
+++ b/Client/src/Compiler/Atributes.cs
@@ -33,3 +33,17 @@ public class CommandAttribute : Attribute
 		Name = name;
 	}
 }
+[AttributeUsage(AttributeTargets.Method)]
+public class ClientRPCAttribute : Attribute
+{
+    public string Name { get; set; }
+
+    public ClientRPCAttribute()
+    {
+    }
+
+    public ClientRPCAttribute(string name)
+    {
+        Name = CompilerHelper.FormatName(name);
+    }
+}

--- a/Client/src/Compiler/CarbonClientPlugin.cs
+++ b/Client/src/Compiler/CarbonClientPlugin.cs
@@ -69,11 +69,13 @@ public abstract class CarbonClientPlugin : FacepunchBehaviour
 	internal void ILoad()
 	{
 		IRefreshHooks();
+		IRegisterRPC();
 		ICommandInstall();
 	}
 	internal void IUnload(bool clear = false)
 	{
 		CommandLoader.UnregisterType(this);
+		RPCLoader.UnregisterPlugin(this);
 		BaseHook.UnsubscribePlugin(this);
 
 		Console.WriteLine($"Unloaded plugin {Info.Name}");
@@ -112,5 +114,9 @@ public abstract class CarbonClientPlugin : FacepunchBehaviour
 	internal void ICommandInstall()
 	{
 		CommandLoader.RegisterType(_pluginType, this);
-	}
+    }
+    internal void IRegisterRPC()
+    {
+		RPCLoader.RegisterPlugin(this);
+    }
 }

--- a/Client/src/Core/CoreHooks.cs
+++ b/Client/src/Core/CoreHooks.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Linq;
 using Carbon.Client.API;
+using Network;
 using UnityEngine;
 
 namespace Carbon.Client.Core;
@@ -61,4 +62,12 @@ public partial class CorePlugin : CarbonClientPlugin
 
 		return null;
 	}
+
+    private object OnRPCMessage(BaseEntity entity, BasePlayer player, uint rpc, Message msg)
+    {
+		if (RPCCaller.CallRPC(entity, player, rpc, msg))
+			return true;
+
+		return null;
+    }
 }

--- a/Client/src/Utility/NonGenericIl2CppConverter.cs
+++ b/Client/src/Utility/NonGenericIl2CppConverter.cs
@@ -1,0 +1,80 @@
+﻿using Il2CppInterop.Runtime.InteropTypes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Carbon.Utility
+{
+    public static class NonGenericIl2CppConverter
+    {
+        private static Dictionary<Type, Func<IntPtr, object>> _converters = new();
+
+        private static readonly MethodInfo _getUninitializedObject = typeof(RuntimeHelpers).GetMethod(nameof(RuntimeHelpers.GetUninitializedObject))!;
+        private static readonly MethodInfo _getTypeFromHandle = typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle))!;
+        private static readonly MethodInfo _createGCHandle = typeof(Il2CppObjectBase).GetMethod("CreateGCHandle")!;
+        private static readonly FieldInfo _isWrapped = typeof(Il2CppObjectBase).GetField("isWrapped")!;
+
+        // based on https://github.com/BepInEx/Il2CppInterop/blob/master/Il2CppInterop.Runtime/InteropTypes/Il2CppObjectBase.cs
+        // but modified for a non-generic usecase
+        public static object Convert(Type type, IntPtr pointer)
+        {
+            if (!_converters.ContainsKey(type))
+            {
+                var dynamicMethod = new DynamicMethod($"Initializer<{type.AssemblyQualifiedName}>", type, new[] { typeof(IntPtr) });
+                dynamicMethod.DefineParameter(0, ParameterAttributes.None, "pointer");
+
+                var il = dynamicMethod.GetILGenerator();
+
+                if (type.GetConstructor(new[] { typeof(IntPtr) }) is { } pointerConstructor)
+                {
+                    // Base case: Il2Cpp constructor => call it directly
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Newobj, pointerConstructor);
+                }
+                else
+                {
+                    // Special case: We have a parameterless constructor
+                    // However, it could be be user-made or implicit
+                    // In that case we set the GCHandle and then call the ctor and let GC destroy any objects created by DerivedConstructorPointer
+
+                    // var obj = (T)FormatterServices.GetUninitializedObject(type);
+                    il.Emit(OpCodes.Ldtoken, type);
+                    il.Emit(OpCodes.Call, _getTypeFromHandle);
+                    il.Emit(OpCodes.Call, _getUninitializedObject);
+                    il.Emit(OpCodes.Castclass, type);
+
+                    // obj.CreateGCHandle(pointer);
+                    il.Emit(OpCodes.Dup);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Callvirt, _createGCHandle);
+
+                    // obj.isWrapped = true;
+                    il.Emit(OpCodes.Dup);
+                    il.Emit(OpCodes.Ldc_I4_1);
+                    il.Emit(OpCodes.Stsfld, _isWrapped);
+
+                    var parameterlessConstructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Type.EmptyTypes);
+                    if (parameterlessConstructor != null)
+                    {
+                        // obj..ctor();
+                        il.Emit(OpCodes.Dup);
+                        il.Emit(OpCodes.Ldarg_0);
+                        il.Emit(OpCodes.Callvirt, parameterlessConstructor);
+                    }
+                }
+                il.Emit(OpCodes.Ret);
+
+                _converters.Add(type, dynamicMethod.CreateDelegate<Func<IntPtr, object>>());
+            }
+
+
+
+            return _converters[type](pointer);
+        }
+    }
+}


### PR DESCRIPTION
this commit adds a way for Plugins to tag methods as RPC methods. it also adds a non generic way of casting Il2Cpp instances to the appropriate type

the core part of this system is the ClientRPC attribute. marking a function with it registers it with the RPC Caller system.
the ClientRPC has one optional argument which is its name, if no name is provided the function name is used
functions tagged with the arguement need to accept an entity instance and the RPCMessage containing the RPC message contents, a return type is optional, if they return true the vanilla behaviour will be prevented.
```cs
// can be static or an instance method
[ClientRPC]
public static bool TestRPC(BaseEntity entity, RPCMessage msg)
{
    return true;
}
```

the entity argument type needs to be assignable to BaseEntity, if a sub type is used the method is only called for RPC calls on entities implementing that subtype. for example:
```cs
[ClientRPC("SignalFromServer")]
public static bool CustomPlayerSignalRPC(BasePlayer entity, RPCMessage msg)
{
    return true;
}
```
this will only get called for SignalFromServer RPCs if the entity it was called from is a/derives from BasePlayer


if the function is an instance method of a type deriving from BaseEntity (say a custom entity), it can also provide a non static method containing just an argument for the RPCMessage, this method will only get called on the entity instance the RPC came from
```cs
public class MyCustomEntity : BaseEntity
{
    [ClientRPC("CustomRPC")]
    public bool OnCustomRPC(RPCMessage msg)
    {
        return true;
    }
}

```